### PR TITLE
Fixed migration bug in 2_create_video_file

### DIFF
--- a/db/migrate/2_create_video_file.rb
+++ b/db/migrate/2_create_video_file.rb
@@ -18,7 +18,7 @@ class CreateVideoFile < ActiveRecord::Migration
 
   def down
 
-    drop_table :refinery_videos
+    drop_table :refinery_video_files
 
   end
 


### PR DESCRIPTION
If you run a migration rollback for 2_create_video_file.rb, will it drop the `refinery_videos` table instead of the `refinery_video_files` table. This fixes that bug.
