### PR TITLE
Fix dialog to work with Refinerycms 2.1.2

### DIFF
--- a/app/views/refinery/videos/admin/videos/append_to_wym.js.erb
+++ b/app/views/refinery/videos/admin/videos/append_to_wym.js.erb
@@ -2,7 +2,7 @@ parent.$.fn.getIndex = function(){
     var $p=$(this).parent().children();
     return $p.index(this);
 }
-selectedPart = parent.$('#page_parts .ui-tabs-selected').getIndex();
+selectedPart = parent.$('#page_parts .ui-tabs-active').getIndex();
 wym = parent.$.wymeditors(selectedPart);
 selectedBlock = wym.selected();
 if (selectedBlock !== null) {


### PR DESCRIPTION
The selected tab class changed on one of the latest refinerycsm versions
